### PR TITLE
ci: 💚 remove skipping continuous integration from release commit

### DIFF
--- a/.github/workflows/cloudrun-source.yml
+++ b/.github/workflows/cloudrun-source.yml
@@ -26,7 +26,7 @@ jobs:
           elif [ "${{ github.event.inputs.environment }}" = "production" ] && [ "${{ github.ref }}" == "refs/heads/prod" ]; then
             echo "SERVICE=ribby" >> "$GITHUB_OUTPUT"
           else
-            echo "ERROR: This workflow should only be triggered on prod or a feature branch."
+            echo "ERROR: This workflow should only be triggered on a production (alpha, beta, prod) or a feature branch."
             exit 1
           fi
       - name: Show Environment type

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -27,7 +27,7 @@ const config = {
 			{
 				assets: ["docs/CHANGELOG.md", "package.json"],
 				message:
-					"chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+					"chore(release): ${nextRelease.version} \n\n${nextRelease.notes}",
 			},
 		],
 		"@semantic-release/github",


### PR DESCRIPTION
# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/TeddTech/ribby/blob/main/.github/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] This pull request has been linted by running `npm run lint-staged` without errors
- [x] This pull request has been tested in **dev** mode by running `npm start` and reviewing affected routes
- [x] This pull request has been built by running `npm run build` without errors
- [x] This isn't a duplicate of an existing pull request

# What is it for?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

- https://stackoverflow.com/questions/61989951/github-action-workflow-not-running/69542205#69542205?newreg=72b3cb9fe66c420b86ce4a19e8765a9b
- https://stackoverflow.com/questions/59439380/can-i-filter-a-github-action-step-based-on-the-commit-message

# Steps to test

1. <!-- First step --> Will not be able to test till next release.

#### Expected behavior: <!-- What should happen --> 
Smooth release with all status checks running and passing.